### PR TITLE
Update submodule URLs (Github has disabled git:// protocol)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "thing-logos"]
 	path = thing-logos
-	url = git://github.com/rohieb/thing-logos.git
+	url = https://github.com/rohieb/thing-logos.git
 [submodule "write"]
 	path = write
-	url = git://github.com/rohieb/Write.scad.git
+	url = https://github.com/rohieb/Write.scad.git


### PR DESCRIPTION
More info: https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/